### PR TITLE
- Added missing line 'use strict; use warnings;' as reported by CPANTS.

### DIFF
--- a/lib/Devel/EndStats/LoadedMods.pm
+++ b/lib/Devel/EndStats/LoadedMods.pm
@@ -2,6 +2,7 @@ package Devel::EndStats::LoadedMods;
 
 # DATE
 # VERSION
+use strict; use warnings;
 
 END {
     print "# BEGIN stats from Devel::EndStats::LoadedMods\n";


### PR DESCRIPTION
Hi,

Please review the proposed fix to the CPANTS warning.

Many Thanks.

Best Regards,
Mohammad S Anwar
